### PR TITLE
fix bug: 上传接口 contentType 修改

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ const getOpts = (customHeader = {}, body, url = "", method = "POST", toStrBody =
         }
     }
     let headers = {
-        contentType: 'multipart/form-data',
+        contentType: 'text/html;charset=UTF-8',
+        // contentType: 'multipart/form-data',
         'User-Agent': 'PicGo'
     }
     if (customHeader) {


### PR DESCRIPTION
上传接口请求的 contentType 应该与 onemanager 上页面的请求接口一致，否则 picgo 提示报错。